### PR TITLE
Added custom action possibility to `Card`

### DIFF
--- a/src/lib/services/store.js
+++ b/src/lib/services/store.js
@@ -8,3 +8,7 @@ export const editingPersonalia = writable({
   editBlock: 'ingen akkurat nå'
 })
 export const infoOpen = writable('')
+export const cardAction = writable({
+  open: false,
+  block: 'ingen akkurat nå'
+})


### PR DESCRIPTION
La til funksjonalitet for å kunne bruke en egen custom action / function i Card.

Jeg trang ikke denne funksjonalitet allikevel, så velger derfor heller å legge denne som en PR som kan merges inn dersom funksjonaliteten trengs en gang 😉

Støtter følgende:
- Custom tekst på actionknappen for å åpne actionen
- Custom tekst på actionknappen for å lagre / utføre / what ever you want
- Custom tekst på actionknappen for retry
- Custom tekst på actionknappen for cancel
- Custom tekst som vises når actionen utføres
- Custom tekst som vises når actionen er fullført
- Custom tekst som vises når actionen tryner